### PR TITLE
Added option -show-errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Usage
         -shell="shell"  : shell for execute command, "" - without shell
         -cache=NNN      : caching command out for NNN seconds
         -one-thread     : run each shell command in one thread
+        -show-errors    : returns the standard output even if the command exits with a non-zero exit code
         -version
         -help
 

--- a/shell2http.go
+++ b/shell2http.go
@@ -31,6 +31,7 @@ Usage:
 		-shell="shell"  : shell for execute command, "" - without shell
 		-cache=NNN      : caching command out for NNN seconds
 		-one-thread     : run each shell command in one thread
+		-show-errors    : returns the standard output even if the command exits with a non-zero exit code
 		-version
 		-help
 
@@ -151,6 +152,7 @@ type Config struct {
 	shell         string // export all current environment vars
 	cache         int    // caching command out (in seconds)
 	oneThread     bool   // run each shell commands in one thread
+	showErrors    bool   // returns the standard output even if the command exits with a non-zero exit code
 }
 
 // ------------------------------------------------------------------
@@ -169,6 +171,7 @@ func getConfig() (cmdHandlers []Command, appConfig Config, err error) {
 	flag.StringVar(&appConfig.shell, "shell", "sh", "custom shell or \"\" for execute without shell")
 	flag.IntVar(&appConfig.cache, "cache", 0, "caching command out (in seconds)")
 	flag.BoolVar(&appConfig.oneThread, "one-thread", false, "run each shell command in one thread")
+	flag.BoolVar(&appConfig.showErrors, "show-errors", false, "returns the standard output even if the command exits with a non-zero exit code")
 	flag.Usage = func() {
 		fmt.Printf("usage: %s [options] /path \"shell command\" /path2 \"shell command2\"\n", os.Args[0])
 		flag.PrintDefaults()
@@ -280,7 +283,7 @@ func getShellHandler(appConfig Config, path string, shell string, params []strin
 		osExecCommand.Stderr = os.Stderr
 		shellOut, err := osExecCommand.Output()
 
-		if err != nil {
+		if err != nil && !appConfig.showErrors {
 			log.Println("exec error: ", err)
 			fmt.Fprint(rw, "exec error: ", err)
 		} else {


### PR DESCRIPTION
returns the standard output even if the command exits with a non-zero exit code