### PR TITLE
Accept basic auth credentials from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ In the `-form` mode, variables are available for shell scripts:
   * $filepath_ID -- uploaded file path, ID - id from `<input type=file name=ID>`, temporary uploaded file will be automatically deleted
   * $filename_ID -- uploaded file name from browser
 
+The credentials for basic authentication may also be provided via the `SH_BASIC_AUTH` environment variable.
+
 Install
 -------
 

--- a/shell2http.1
+++ b/shell2http.1
@@ -51,6 +51,9 @@ $filename_ID \-\- uploaded file name from browser
 .
 .IP "" 0
 .
+.P
+The credentials for basic authentication may also be provided via the \fBSH_BASIC_AUTH\fR environment variable.
+.
 .SH "Install"
 MacOS:
 .


### PR DESCRIPTION
Provide basic auth credentials via `SH_BASIC_AUTH` environment variable.
This prevents the credentials from being published in process list.
This special environment variable is not exposed to the executed
commands, even if `-export-all-vars` is given.