### PR TITLE
Pass request body data to STDIN for PUT, PATCH

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Usage
         -form           : parse query into environment vars, handle uploaded files
         -cgi            : run scripts in CGI-mode:
                           - set environment variables with HTTP-request information
-                          - write POST-data to script STDIN (if is not set -form)
+                          - write POST|PUT|PATCH-data to script STDIN (if is not set -form)
                           - parse headers from script (eg: "Location: URL\n\n")
         -export-vars=var: export environment vars ("VAR1,VAR2,...")
                           by default export PATH, HOME, LANG, USER, TMPDIR

--- a/doc.go
+++ b/doc.go
@@ -21,7 +21,7 @@ Usage:
 		-form           : parse query into environment vars, handle uploaded files
 		-cgi            : run scripts in CGI-mode:
 		                  - set environment variables with HTTP-request information
-		                  - write POST-data to script STDIN (if not set -form)
+		                  - write POST|PUT|PATCH-data to script STDIN (if not set -form)
 		                  - parse headers from script (eg: "Location: URL\n\n")
 		-export-vars=var: export environment vars ("VAR1,VAR2,...")
 		-export-all-vars: export all current environment vars

--- a/shell2http.go
+++ b/shell2http.go
@@ -368,10 +368,10 @@ func execShellCommand(appConfig Config, shell string, params []string, req *http
 	if appConfig.setCGI {
 		setCGIEnv(osExecCommand, req, appConfig)
 
-		// get POST data to stdin of script (if not parse form vars above)
-		if req.Method == "POST" && !appConfig.setForm {
+		// get request body data data to stdin of script (if not parse form vars above)
+		if (req.Method == "POST" || req.Method == "PUT" || req.Method == "PATCH") && !appConfig.setForm {
 			if stdin, pipeErr := osExecCommand.StdinPipe(); pipeErr != nil {
-				log.Println("write POST data to shell failed:", pipeErr)
+				log.Println("write request body data to shell failed:", pipeErr)
 			} else {
 				waitPipeWrite = true
 				go func() {
@@ -394,7 +394,7 @@ func execShellCommand(appConfig Config, shell string, params []string, req *http
 
 	if waitPipeWrite {
 		if pipeErr := <-pipeErrCh; pipeErr != nil {
-			log.Println("write POST data to shell failed:", pipeErr)
+			log.Println("write request body data to shell failed:", pipeErr)
 		}
 	}
 


### PR DESCRIPTION
Currently shell2http allows passing of request body data, when the request method is `POST`. This PR extends this support to all allowed request methods. Those are `PUT` and `PATCH`.

See [this specification](https://specs.openstack.org/openstack/api-wg/guidelines/http/methods.html) for the details regarding the HTTP methods.