### PR TITLE
[Fix] When shell command exec error, we also want to know the previous stdout

### DIFF
--- a/shell2http.go
+++ b/shell2http.go
@@ -139,13 +139,13 @@ func getShellHandler(appConfig Config, shell string, params []string, cacheTTL r
 	return func(rw http.ResponseWriter, req *http.Request) {
 		shellOut, exitCode, err := execShellCommand(appConfig, shell, params, req, cacheTTL)
 		if err != nil {
-			log.Println("exec error: ", err)
+			log.Println(string(shellOut), "\nexec error: ", err)
 		}
 
 		rw.Header().Set("X-Shell2http-Exit-Code", strconv.Itoa(exitCode))
 
 		if err != nil && !appConfig.showErrors {
-			responseWrite(rw, "exec error: "+err.Error())
+			responseWrite(rw, string(shellOut)+"\nexec error: "+err.Error())
 		} else {
 			outText := string(shellOut)
 			if appConfig.setCGI {

--- a/shell2http_test.go
+++ b/shell2http_test.go
@@ -227,7 +227,7 @@ func Test_main(t *testing.T) {
 	)
 
 	testHTTP(t, "GET", "http://localhost:"+port+"/error", "",
-		func(res string) bool { return strings.HasPrefix(res, "exec error:") },
+		func(res string) bool { return strings.Contains(res, "exec error:") },
 		"5. error",
 	)
 


### PR DESCRIPTION
we need to know which steps we are, when we meet error<p>
so we should print the shellOut