### PR TITLE
Fix  #112: Can't handle upload file when 'boundary‘’ parameter string without space or 'multipart/form-data' contains uppercase characters

### DIFF
--- a/shell2http.go
+++ b/shell2http.go
@@ -523,7 +523,7 @@ func getForm(cmd *exec.Cmd, req *http.Request, checkFormRe *regexp.Regexp) (func
 
 // isMultipartFormData - check header for multipart/form-data
 func isMultipartFormData(headers http.Header) bool {
-	if contentType, ok := headers["Content-Type"]; ok && len(contentType) == 1 && strings.HasPrefix(contentType[0], "multipart/form-data; ") {
+	if contentType, ok := headers["Content-Type"]; ok && len(contentType) == 1 && strings.HasPrefix(contentType[0], "multipart/form-data;") {
 		return true
 	}
 

--- a/shell2http.go
+++ b/shell2http.go
@@ -523,7 +523,7 @@ func getForm(cmd *exec.Cmd, req *http.Request, checkFormRe *regexp.Regexp) (func
 
 // isMultipartFormData - check header for multipart/form-data
 func isMultipartFormData(headers http.Header) bool {
-	if contentType, ok := headers["Content-Type"]; ok && len(contentType) == 1 && strings.HasPrefix(contentType[0], "multipart/form-data;") {
+	if contentType, ok := headers["Content-Type"]; ok && len(contentType) == 1 && strings.HasPrefix(strings.ToLower(contentType[0]), "multipart/form-data;") {
 		return true
 	}
 


### PR DESCRIPTION
#112 